### PR TITLE
Fixed error propagation from ConcurrentRunner

### DIFF
--- a/testsupport/src/main/java/org/sonatype/goodies/testsupport/concurrent/ConcurrentTestContext.java
+++ b/testsupport/src/main/java/org/sonatype/goodies/testsupport/concurrent/ConcurrentTestContext.java
@@ -73,8 +73,8 @@ class ConcurrentTestContext
     try {
       iterationStartSignal.await(0, TimeUnit.SECONDS);
     }
-    catch (InterruptedException | BrokenBarrierException | TimeoutException ignored) {
-      // NOSONAR we wanted to break the barrier, well we did it
+    catch (InterruptedException | BrokenBarrierException | TimeoutException ignored) { // NOSONAR
+      // we wanted to break the barrier, well we did it
     }
   }
 

--- a/testsupport/src/test/java/org/sonatype/goodies/testsupport/concurrent/ConcurrentRunnerTest.java
+++ b/testsupport/src/test/java/org/sonatype/goodies/testsupport/concurrent/ConcurrentRunnerTest.java
@@ -65,7 +65,7 @@ public class ConcurrentRunnerTest
     {
       @Override
       public void run() throws Exception {
-        // allow the first task to complete and proceed to wait on the barrier
+        // this task allows the first to complete and to wait on the barrier
         Thread.sleep(200);
         throw new IllegalStateException();
       }

--- a/testsupport/src/test/java/org/sonatype/goodies/testsupport/concurrent/ConcurrentRunnerTest.java
+++ b/testsupport/src/test/java/org/sonatype/goodies/testsupport/concurrent/ConcurrentRunnerTest.java
@@ -52,12 +52,21 @@ public class ConcurrentRunnerTest
 
   @Test(expected = IllegalStateException.class)
   public void taskExceptionPropagatesOut() throws Exception {
-    final ConcurrentRunner runner = new ConcurrentRunner(1, 10);
+    final ConcurrentRunner runner = new ConcurrentRunner(2, 10);
 
     runner.addTask(new ConcurrentTask()
     {
       @Override
       public void run() throws Exception {
+        // a quick and happy task that happens to be first in the internal task list
+      }
+    });
+    runner.addTask(new ConcurrentTask()
+    {
+      @Override
+      public void run() throws Exception {
+        // allow the first task to complete and proceed to wait on the barrier
+        Thread.sleep(200);
         throw new IllegalStateException();
       }
     });

--- a/testsupport/src/test/java/org/sonatype/goodies/testsupport/concurrent/ConcurrentTestContextTest.java
+++ b/testsupport/src/test/java/org/sonatype/goodies/testsupport/concurrent/ConcurrentTestContextTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2010-present Sonatype, Inc. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.sonatype.goodies.testsupport.concurrent;
+
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link ConcurrentTestContext}.
+ */
+public class ConcurrentTestContextTest
+{
+  @Test(expected = BrokenBarrierException.class)
+  public void testAwaitIterationStart_FailFastWhenFailureOccurredAlready() throws Exception {
+    ConcurrentTestContext context = new ConcurrentTestContext(new CyclicBarrier(2), new AtomicBoolean(), 2,
+        new AtomicInteger(), 3);
+    context.indicateFailure();
+    context.awaitIterationStart();
+  }
+}


### PR DESCRIPTION
http://bamboo.s/browse/OSS-GOODIESF13-3

Currently `ConcurrentTestWorker` records `BrokenBarrierException` as a failure of its task and together with https://github.com/sonatype/goodies/blob/a1573364ce72fe784714bae0bbd5d381f7f58345/testsupport/src/main/java/org/sonatype/goodies/testsupport/concurrent/ConcurrentRunner.java#L150, if the first task in the list observes the broken barrier, this is reported as the failure of the concurrent run. But what one rather wants to get propagated is the failure from the task that reset/broke the barrier in the first place because it encountered a real task error.