### PR TITLE
Fix invalid ISO 8601 datetime fomat

### DIFF
--- a/common/src/main/java/org/sonatype/goodies/common/Iso8601Date.java
+++ b/common/src/main/java/org/sonatype/goodies/common/Iso8601Date.java
@@ -26,8 +26,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class Iso8601Date
 {
-  public static final String PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"; //NON-NLS
-  //public static final String PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZ";
+  public static final String PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"; //NON-NLS
   //public static final String PATTERN = "yyyy-MM-dd'T'HH:mm:ss";
 
   /**

--- a/common/src/test/java/org/sonatype/goodies/common/Iso8601DateTest.java
+++ b/common/src/test/java/org/sonatype/goodies/common/Iso8601DateTest.java
@@ -13,6 +13,7 @@
 package org.sonatype.goodies.common;
 
 import java.util.Date;
+import java.util.TimeZone;
 
 import org.sonatype.goodies.testsupport.TestSupport;
 
@@ -38,5 +39,29 @@ public class Iso8601DateTest
     assertNotNull(date2);
 
     assertEquals(date1.getTime(), date2.getTime());
+  }
+
+  @Test
+  public void testFormatParseExpected() throws Exception {
+    String formatted1 = "2016-10-01T20:00:00.123Z";
+
+    Date date = Iso8601Date.parse(formatted1);
+    assertNotNull(date);
+
+    TimeZone savedTimeZone = TimeZone.getDefault();
+    TimeZone zuluTimeZone = TimeZone.getTimeZone("Etc/UTC");
+
+    String formatted2 = null;
+
+    try {
+      TimeZone.setDefault(zuluTimeZone);
+      formatted2 = Iso8601Date.format(date);
+    } finally {
+      TimeZone.setDefault(savedTimeZone);
+    }
+
+    assertNotNull(formatted2);
+
+    assertEquals(formatted1, formatted2);
   }
 }


### PR DESCRIPTION
SimpleDateFormat used Z as timezone, though this is invalid because it is a RFC
timezone and not an ISO 8601 timezone. Use XXX format for ISO-compliant timezone
format.
