### PR TITLE
Improved exception reporting by ConcurrentRunner

### DIFF
--- a/testsupport/src/test/java/org/sonatype/goodies/testsupport/concurrent/ConcurrentRunnerTest.java
+++ b/testsupport/src/test/java/org/sonatype/goodies/testsupport/concurrent/ConcurrentRunnerTest.java
@@ -12,6 +12,8 @@
  */
 package org.sonatype.goodies.testsupport.concurrent;
 
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.sonatype.goodies.testsupport.TestSupport;
@@ -84,6 +86,28 @@ public class ConcurrentRunnerTest
       public void run() throws Exception {
         // Sleep for 50 seconds, way past the timeout
         Thread.sleep(50 * 1000);
+      }
+    });
+
+    runner.go();
+  }
+
+  @Test(expected = TimeoutException.class)
+  public void testBrokenBarrierExceptionIgnoredInFavorOfMoreSpecificCause() throws Exception {
+    final ConcurrentRunner runner = new ConcurrentRunner(1, 10);
+
+    runner.addTask(new ConcurrentTask()
+    {
+      @Override
+      public void run() throws Exception {
+        throw new BrokenBarrierException("unwanted");
+      }
+    });
+    runner.addTask(new ConcurrentTask()
+    {
+      @Override
+      public void run() throws Exception {
+        throw new TimeoutException("wanted");
       }
     });
 


### PR DESCRIPTION
The other day I observed tests failing with `BrokenBarrierException`, inspecting the logs showed that this was merely a consequence of an exception encountered by another worker thread, like a `TimeoutException` as seen below:
````
2016-09-24 15:50:56,928-0400 INFO  [pool-41-thread-8] *SYSTEM org.sonatype.goodies.testsupport.concurrent.ConcurrentTestWorker - Test worker 7's task threw exception
java.util.concurrent.BrokenBarrierException: null
	at java.util.concurrent.CyclicBarrier.dowait(CyclicBarrier.java:250) [na:1.8.0_45]
	at java.util.concurrent.CyclicBarrier.await(CyclicBarrier.java:435) [na:1.8.0_45]
	at org.sonatype.goodies.testsupport.concurrent.ConcurrentTestContext.awaitIterationStart(ConcurrentTestContext.java:82) [org.sonatype.nexus.pax-exam:3.1.0.SNAPSHOT]
	at org.sonatype.goodies.testsupport.concurrent.ConcurrentTestWorker.call(ConcurrentTestWorker.java:58) [org.sonatype.nexus.pax-exam:3.1.0.SNAPSHOT]
	at org.sonatype.goodies.testsupport.concurrent.ConcurrentTestWorker.call(ConcurrentTestWorker.java:31) [org.sonatype.nexus.pax-exam:3.1.0.SNAPSHOT]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [na:1.8.0_45]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_45]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_45]
	at java.lang.Thread.run(Thread.java:745) [na:1.8.0_45]
2016-09-24 15:50:56,928-0400 INFO  [pool-41-thread-7] *SYSTEM org.sonatype.goodies.testsupport.concurrent.ConcurrentTestWorker - Test worker 6's task threw exception
java.util.concurrent.TimeoutException: null
	at java.util.concurrent.CyclicBarrier.dowait(CyclicBarrier.java:257) [na:1.8.0_45]
	at java.util.concurrent.CyclicBarrier.await(CyclicBarrier.java:435) [na:1.8.0_45]
	at org.sonatype.goodies.testsupport.concurrent.ConcurrentTestContext.awaitIterationStart(ConcurrentTestContext.java:82) [org.sonatype.nexus.pax-exam:3.1.0.SNAPSHOT]
	at org.sonatype.goodies.testsupport.concurrent.ConcurrentTestWorker.call(ConcurrentTestWorker.java:58) [org.sonatype.nexus.pax-exam:3.1.0.SNAPSHOT]
	at org.sonatype.goodies.testsupport.concurrent.ConcurrentTestWorker.call(ConcurrentTestWorker.java:31) [org.sonatype.nexus.pax-exam:3.1.0.SNAPSHOT]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [na:1.8.0_45]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_45]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_45]
	at java.lang.Thread.run(Thread.java:745) [na:1.8.0_45]
````

The change here is to have Surefire/Failsafe report the original/specific failure, not a consequence thereof.