### PR TITLE
Report j.l.Error instances from ConcurrentTestWorker

### DIFF
--- a/testsupport/src/main/java/org/sonatype/goodies/testsupport/concurrent/ConcurrentTestWorker.java
+++ b/testsupport/src/main/java/org/sonatype/goodies/testsupport/concurrent/ConcurrentTestWorker.java
@@ -71,7 +71,7 @@ class ConcurrentTestWorker
         log.info("Test worker {} completing iteration {}", workerNumber, i);
       }
     }
-    catch (Exception | AssertionError e) {
+    catch (Throwable e) {
       log.info("Test worker {}'s task threw exception", workerNumber, e);
       context.indicateFailure();
       this.exception.set(e);

--- a/testsupport/src/main/java/org/sonatype/goodies/testsupport/concurrent/ConcurrentTestWorker.java
+++ b/testsupport/src/main/java/org/sonatype/goodies/testsupport/concurrent/ConcurrentTestWorker.java
@@ -71,7 +71,7 @@ class ConcurrentTestWorker
         log.info("Test worker {} completing iteration {}", workerNumber, i);
       }
     }
-    catch (Throwable e) {
+    catch (Throwable e) { // NOSONAR
       log.info("Test worker {}'s task threw exception", workerNumber, e);
       context.indicateFailure();
       this.exception.set(e);

--- a/testsupport/src/test/java/org/sonatype/goodies/testsupport/concurrent/ConcurrentRunnerTest.java
+++ b/testsupport/src/test/java/org/sonatype/goodies/testsupport/concurrent/ConcurrentRunnerTest.java
@@ -113,4 +113,18 @@ public class ConcurrentRunnerTest
 
     runner.go();
   }
+
+  @Test(expected = Error.class)
+  public void testPropagateTaskErrors() throws Exception {
+    final ConcurrentRunner runner = new ConcurrentRunner(1, 10);
+    runner.addTask(1, new ConcurrentTask()
+    {
+      @Override
+      public void run() {
+        throw new Error("Something went terribly wrong");
+      }
+    });
+
+    runner.go();
+  }
 }


### PR DESCRIPTION
http://bamboo.s/browse/OSS-GOODIESF18-1

````
--- failed task run whose cause isn't reported
2016-10-22 20:04:15,298-0400 INFO  [pool-41-thread-7] *SYSTEM com.sonatype.nexus.repository.testsupport.pypi.PyPiClient - Requesting GET http://localhost:34778/repository/concurrentProxyTest/simple/bpackage/ HTTP/1.1
2016-10-22 20:04:15,894-0400 INFO  [pool-41-thread-7] *SYSTEM com.sonatype.nexus.repository.testsupport.pypi.PyPiClient - Received HttpResponseProxy{HTTP/1.1 200 OK [Date: Sun, 23 Oct 2016 00:04:15 GMT, Server: Nexus/3.1.0-SNAPSHOT (OSS), X-Frame-Options: SAMEORIGIN, X-Content-Type-Options: nosniff, Last-Modified: Sun, 23 Oct 2016 00:04:15 GMT, Content-Type: text/html, Content-Length: 488] ResponseEntityProxy{[Content-Type: text/html,Content-Length: 488,Chunked: false]}}
--- the absence of further logs from this thread suggests ConcurrentTask.run() threw an exception the test worker didn't catch
2016-10-22 20:04:16,009-0400 INFO  [pool-41-thread-7] *SYSTEM org.sonatype.goodies.testsupport.concurrent.ConcurrentTestWorker - Test worker 6 done

--- this is a healthy task run for comparison
2016-10-22 20:04:15,297-0400 INFO  [pool-41-thread-6] *SYSTEM com.sonatype.nexus.repository.testsupport.pypi.PyPiClient - Requesting GET http://localhost:34778/repository/concurrentProxyTest/simple/bpackage/ HTTP/1.1
2016-10-22 20:04:15,985-0400 INFO  [pool-41-thread-6] *SYSTEM com.sonatype.nexus.repository.testsupport.pypi.PyPiClient - Received HttpResponseProxy{HTTP/1.1 200 OK [Date: Sun, 23 Oct 2016 00:04:15 GMT, Server: Nexus/3.1.0-SNAPSHOT (OSS), X-Frame-Options: SAMEORIGIN, X-Content-Type-Options: nosniff, Last-Modified: Sun, 23 Oct 2016 00:04:15 GMT, Content-Type: text/html, Content-Length: 488] ResponseEntityProxy{[Content-Type: text/html,Content-Length: 488,Chunked: false]}}
2016-10-22 20:04:16,044-0400 INFO  [pool-41-thread-6] *SYSTEM com.sonatype.nexus.repository.testsupport.pypi.PyPiClient - Requesting GET http://localhost:34778/repository/concurrentProxyTest/packages/00/01/02/bpackage-2.1.0-py2.py3-none-any.whl HTTP/1.1
2016-10-22 20:04:16,156-0400 INFO  [pool-41-thread-6] *SYSTEM com.sonatype.nexus.repository.testsupport.pypi.PyPiClient - Received HttpResponseProxy{HTTP/1.1 200 OK [Date: Sun, 23 Oct 2016 00:04:16 GMT, Server: Nexus/3.1.0-SNAPSHOT (OSS), X-Frame-Options: SAMEORIGIN, X-Content-Type-Options: nosniff, Last-Modified: Sun, 23 Oct 2016 00:04:16 GMT, Content-Type: application/zip, Content-Length: 22] ResponseEntityProxy{[Content-Type: application/zip,Content-Length: 22,Chunked: false]}}
2016-10-22 20:04:16,163-0400 INFO  [pool-41-thread-6] *SYSTEM org.sonatype.goodies.testsupport.concurrent.ConcurrentTestWorker - Test worker 5 completing iteration 0

--- because one task runner (test worker 6) quit before it completed all iterations, the others now time out waiting for it to join the cyclic barrier
2016-10-22 20:05:56,170-0400 INFO  [pool-41-thread-6] *SYSTEM org.sonatype.goodies.testsupport.concurrent.ConcurrentTestWorker - Test worker 5's task threw exception
java.util.concurrent.TimeoutException: null
	at java.util.concurrent.CyclicBarrier.dowait(CyclicBarrier.java:257) [na:1.8.0_45]
	at java.util.concurrent.CyclicBarrier.await(CyclicBarrier.java:435) [na:1.8.0_45]
	at org.sonatype.goodies.testsupport.concurrent.ConcurrentTestContext.awaitIterationStart(ConcurrentTestContext.java:82)
````

The end result is still a test failure but as is, the cause is unknown and in particular cannot be fixed.