### PR TITLE
Make PortRegistry avoid ephemeral ports

### DIFF
--- a/testsupport/src/main/java/org/sonatype/goodies/testsupport/port/PortRegistry.java
+++ b/testsupport/src/main/java/org/sonatype/goodies/testsupport/port/PortRegistry.java
@@ -66,8 +66,8 @@ public class PortRegistry
 
   public PortRegistry() {
     // The port range below is chosen to not overlap with the range typically used for ephemeral ports. This helps to
-    // avoid situations where a previously reserved port ends being unavailable for its intended purpose because the OS
-    // has reused the port to satisfy some other ephemeral port request in the meantime.
+    // avoid situations where a previously reserved port ends up being unavailable for its intended purpose because the
+    // OS has reused the port to satisfy some other ephemeral port request in the meantime.
     this(10000, 30000, 60 * 1000);
   }
 

--- a/testsupport/src/test/java/org/sonatype/goodies/testsupport/port/PortRegistryTest.java
+++ b/testsupport/src/test/java/org/sonatype/goodies/testsupport/port/PortRegistryTest.java
@@ -53,7 +53,7 @@ public class PortRegistryTest
 
   @Test
   public void blockedSetOfPortsShouldNeverBeReservable() throws Exception {
-    PortRegistry spied = new PortRegistry();
+    PortRegistry spied = new PortRegistry(0, 0, 100);
     spied.blockPorts(Sets.newSet(1));
     portRegistry = spy(spied);
     doReturn(1).when(portRegistry).findFreePort();
@@ -67,7 +67,7 @@ public class PortRegistryTest
 
   @Test
   public void blockedRangeOfPortsShouldNeverBeReservable() throws Exception {
-    PortRegistry spied = new PortRegistry();
+    PortRegistry spied = new PortRegistry(0, 0, 100);
     spied.blockPorts(Range.closed(1,1));
     portRegistry = spy(spied);
     doReturn(1).when(portRegistry).findFreePort();
@@ -81,7 +81,7 @@ public class PortRegistryTest
 
   @Test
   public void addedBlockedRangeForPreviouslyUnsetRangeIsBlocked() throws Exception {
-    portRegistry = spy(new PortRegistry());
+    portRegistry = spy(new PortRegistry(0, 0, 100));
     doReturn(1).when(portRegistry).findFreePort();
     portRegistry.blockPorts(Range.closed(1, 1));
     assertCannotReservePort();
@@ -89,7 +89,7 @@ public class PortRegistryTest
 
   @Test
   public void addedBlockedRangeIntersectingPreviouslyAddedRangeBlocksReservation() throws Exception {
-    portRegistry = spy(new PortRegistry());
+    portRegistry = spy(new PortRegistry(0, 0, 100));
     portRegistry.blockPorts(Range.closed(2, 5));
     portRegistry.blockPorts(Range.closed(3, 7));
 
@@ -101,7 +101,7 @@ public class PortRegistryTest
 
   @Test
   public void addedBlockedRangeDisparateFromPreviouslyAddedRangeBlocksReservation() throws Exception {
-    portRegistry = spy(new PortRegistry());
+    portRegistry = spy(new PortRegistry(0, 0, 100));
     portRegistry.blockPorts(Range.closed(2, 5));
     portRegistry.blockPorts(Range.closed(7, 10));
 
@@ -118,7 +118,7 @@ public class PortRegistryTest
 
   @Test
   public void multipleRangesCanBlocked() throws Exception {
-    portRegistry = spy(new PortRegistry());
+    portRegistry = spy(new PortRegistry(0, 0, 100));
     portRegistry.blockPorts(Range.closed(2, 5));
     portRegistry.blockPorts(Range.closed(7, 10));
 
@@ -139,6 +139,13 @@ public class PortRegistryTest
     doReturn(13).when(portRegistry).findFreePort();
     assertReservePort(portRegistry, 13);
 
+  }
+
+  @Test
+  public void largeBlockedRangeCanBeSkippedOver() throws Exception {
+    portRegistry = new PortRegistry(15000, 30000, 30 * 1000);
+    portRegistry.blockPorts(Range.closed(15000, 16000));
+    assertTrue(portRegistry.reservePort() > 16000);
   }
 
   private void assertCannotReservePort() {


### PR DESCRIPTION
http://bamboo.s/browse/OSS-GOODIESF19-1

Some of the sporadic IT failures we see are due to "reserved" ports being unavailable for their intended use because the OS reused the port in the meantime. So far I had been trying to identify and fix those other port usages which are however tedious to locate, hard to change and lastly fragile with regard to future code evolution. Today it finally dawned on me that there is a more general cure, addressing the root cause: Not using ephemeral ports to begin with. Manually scanning a port range for a free one isn't rocket science, sure, the OS might do it faster but with only ~10 seconds to scan 64k ports the manual search is hardly an issue.