### PR TITLE
trying to avoid potential collisions in shared storage

### DIFF
--- a/common/src/main/java/org/sonatype/goodies/common/FileReplacer.java
+++ b/common/src/main/java/org/sonatype/goodies/common/FileReplacer.java
@@ -53,7 +53,7 @@ public class FileReplacer
     // and delay creation of file until needed in the case of backup file
     // counter here just to ensure that sub-mills usage will not conflict
 
-    this.filePrefix = file.getName() + "-" + UUID.randomUUID().toString() + "-" + counter.getAndIncrement();
+    this.filePrefix = file.getName() + "-" + UUID.randomUUID() + "-" + counter.getAndIncrement();
     this.tempFile = new File(file.getParentFile(), filePrefix + ".tmp");
     this.backupFile = new File(file.getParentFile(), filePrefix + ".bak");
 

--- a/common/src/main/java/org/sonatype/goodies/common/FileReplacer.java
+++ b/common/src/main/java/org/sonatype/goodies/common/FileReplacer.java
@@ -16,6 +16,7 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.common.io.Files;
@@ -52,7 +53,7 @@ public class FileReplacer
     // and delay creation of file until needed in the case of backup file
     // counter here just to ensure that sub-mills usage will not conflict
 
-    this.filePrefix = file.getName() + "-" + System.currentTimeMillis() + "-" + counter.getAndIncrement();
+    this.filePrefix = file.getName() + "-" + UUID.randomUUID().toString() + "-" + counter.getAndIncrement();
     this.tempFile = new File(file.getParentFile(), filePrefix + ".tmp");
     this.backupFile = new File(file.getParentFile(), filePrefix + ".bak");
 


### PR DESCRIPTION
While testing nxrm3 in HA, we ended up two hosts colliding. Although the current time in millis would seem unlikely to collide, there are various factors such as clock granularity as well as the fact that we were running on VMs that could increase the likelihood of collisions. I'm thinking that UUID should be a safe bet here. 