### PR TITLE
[NEXUS-20161] lifecycle state mismatch doesnt unlock

### DIFF
--- a/lifecycle/src/main/java/org/sonatype/goodies/lifecycle/LifecycleSupport.java
+++ b/lifecycle/src/main/java/org/sonatype/goodies/lifecycle/LifecycleSupport.java
@@ -98,15 +98,17 @@ public class LifecycleSupport
   @Override
   public final void start() throws Exception {
     Lock lock = Locks.write(readWriteLock);
-    ensure(State.NEW, State.STOPPED);
     try {
-      logTransition("Starting");
-      doStart();
-      current = State.STARTED;
-      logTransition("Started");
-    }
-    catch (Throwable failure) {
-      doFailed("start", failure);
+      ensure(State.NEW, State.STOPPED);
+      try {
+        logTransition("Starting");
+        doStart();
+        current = State.STARTED;
+        logTransition("Started");
+      }
+      catch (Throwable failure) {
+        doFailed("start", failure);
+      }
     }
     finally {
       lock.unlock();
@@ -132,15 +134,17 @@ public class LifecycleSupport
   @Override
   public final void stop() throws Exception {
     Lock lock = Locks.write(readWriteLock);
-    ensure(State.STARTED);
     try {
-      logTransition("Stopping");
-      doStop();
-      current = State.STOPPED;
-      logTransition("Stopped");
-    }
-    catch (Throwable failure) {
-      doFailed("stop", failure);
+      ensure(State.STARTED);
+      try {
+        logTransition("Stopping");
+        doStop();
+        current = State.STOPPED;
+        logTransition("Stopped");
+      }
+      catch (Throwable failure) {
+        doFailed("stop", failure);
+      }
     }
     finally {
       lock.unlock();


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-20161

Adjusted the `try..finally..unlock` to cover the state check

Also simplified the locking to use `volatile+lock` with pre-checks to avoid locking if we know the state is wrong at the time of the request. We can do this because the only thing done under the read lock is checking a single field. (If the state was right then we have to check it again once we have the lock, as per double-check locking semantics which are valid in Java5+)