### PR TITLE
Fix memory leak in mockito tests

### DIFF
--- a/testsupport/src/main/java/org/sonatype/goodies/testsupport/TestSupport.java
+++ b/testsupport/src/main/java/org/sonatype/goodies/testsupport/TestSupport.java
@@ -17,6 +17,7 @@ import org.sonatype.gossip.Level;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.slf4j.Logger;
 
@@ -48,6 +49,9 @@ public class TestSupport
 
   @After
   public void closeMocks() throws Exception {
+    // fix memory leak in mockito-inline calling method on mock with at least a mock as parameter
+    Mockito.framework().clearInlineMocks();
+
     if (mocks != null) {
       mocks.close();
     }


### PR DESCRIPTION
**Description:**
This is a known mockito issue with the memory leak. Take a look at the https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/MockitoFramework.html#clearInlineMocks()
