### PR TITLE
Fix NotAMockException

### DIFF
--- a/testsupport/src/main/java/org/sonatype/goodies/testsupport/TestSupport.java
+++ b/testsupport/src/main/java/org/sonatype/goodies/testsupport/TestSupport.java
@@ -15,6 +15,7 @@ package org.sonatype.goodies.testsupport;
 import org.sonatype.gossip.Level;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
 import org.mockito.Mockito;
@@ -49,12 +50,15 @@ public class TestSupport
 
   @After
   public void closeMocks() throws Exception {
-    // fix memory leak in mockito-inline calling method on mock with at least a mock as parameter
-    Mockito.framework().clearInlineMocks();
-
     if (mocks != null) {
       mocks.close();
     }
+  }
+
+  @AfterClass
+  public static void clearInlineMocks() {
+    // fix memory leak in mockito-inline calling method on mock with at least a mock as parameter
+    Mockito.framework().clearInlineMocks();
   }
 
   public Level getLogLevel() {


### PR DESCRIPTION
Fix the `org.mockito.exceptions.misusing.NotAMockException: Argument should be a mock, but is: class `