### PR TITLE
BNR-1228 Publish releases to maven central.

### DIFF
--- a/jenkins/Jenkinsfile-release
+++ b/jenkins/Jenkinsfile-release
@@ -1,9 +1,11 @@
 library('private-pipeline-library')
 library('jenkins-shared')
 
-mavenReleasePipeline(usePublicSettingsXmlFile: true,
+mavenReleasePipeline(
         deployBranch: 'main',
         mavenVersion: 'Maven 3.5.x',
+        mavenSettingsFile: 'rsc-private-settings', // internal publishing to rsc
+        additionalReleaseProfiles: ['publish-central'], // public publishing to central
         onSuccess: { build, env ->
             notifyChat(env: env, currentBuild: build, room: 'nxrm-notifications')
         },

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.sonatype.buildsupport</groupId>
     <artifactId>public-parent</artifactId>
-    <version>39</version>
+    <version>42</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
https://sonatype.atlassian.net/browse/BNR-1228
https://jenkins.ci.sonatype.dev/job/nxrm/job/libraries/job/goodies-feature/job/BNR-1228_central_publishing/

Makes use of https://github.com/sonatype/buildsupport/releases/tag/release-42 which has the `publish-central` profile.  Not entirely sure it will attempt to publish both internally and to central, but if it does push internally we want it to go to rsc-private.

I'll want to create a new release based upon this change to test publishing directly to central.