### PR TITLE
Upgrade hamcrest to 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,13 +192,13 @@
       <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-core</artifactId>
-        <version>1.3</version>
+        <version>2.2</version>
       </dependency>
 
       <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-library</artifactId>
-        <version>1.3</version>
+        <version>2.2</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
https://jenkins.ci.sonatype.dev/job/nxrm/job/libraries/job/goodies-feature/job/NEXUS-42105_upgrade_hamcrest/

**Description**
Refer to [NEXUS-42105](https://sonatype.atlassian.net/browse/NEXUS-42105) where we have conflicts with these old `hamcrest` dependency

[NEXUS-42105]: https://sonatype.atlassian.net/browse/NEXUS-42105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ