### PR TITLE
Upgrade to mockito 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <eclipse-sisu.version>0.3.5</eclipse-sisu.version>
     <eclipse-jetty.version>9.4.56.v20240826</eclipse-jetty.version>
     <jupiter.version>5.11.3</jupiter.version>
-    <mockito.version>4.11.0</mockito.version>
+    <mockito.version>5.14.2</mockito.version>
 
     <!--
     Sonar configuration.
@@ -221,7 +221,7 @@
 
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-inline</artifactId>
+        <artifactId>mockito-core</artifactId>
         <version>${mockito.version}</version>
       </dependency>
 

--- a/testsupport/pom.xml
+++ b/testsupport/pom.xml
@@ -93,7 +93,7 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
With the change to Java 17 we can update to Mockito 5.x